### PR TITLE
feat: scaffold template repository with placeholder replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   },
   "dependencies": {
     "@clack/prompts": "1.0.0",
-    "citty": "0.2.0"
+    "@octokit/rest": "^22.0.1",
+    "citty": "0.2.0",
+    "cli-ascii-logo": "^2.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "20.4.1",
@@ -50,6 +52,7 @@
     "globals": "17.3.0",
     "husky": "9.1.7",
     "lint-staged": "16.2.7",
+    "memfs": "^4.56.10",
     "prettier": "3.8.1",
     "release-it": "19.2.4",
     "release-it-pnpm": "4.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@clack/prompts':
         specifier: 1.0.0
         version: 1.0.0
+      '@octokit/rest':
+        specifier: ^22.0.1
+        version: 22.0.1
       citty:
         specifier: 0.2.0
         version: 0.2.0
+      cli-ascii-logo:
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@commitlint/cli':
         specifier: 20.4.1
@@ -51,6 +57,9 @@ importers:
       lint-staged:
         specifier: 16.2.7
         version: 16.2.7
+      memfs:
+        specifier: ^4.56.10
+        version: 4.56.10(tslib@2.8.1)
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -547,6 +556,126 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@1.0.0':
+    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.56.10':
+    resolution: {integrity: sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.56.10':
+    resolution: {integrity: sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.56.10':
+    resolution: {integrity: sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.56.10':
+    resolution: {integrity: sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.56.10':
+    resolution: {integrity: sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.56.10':
+    resolution: {integrity: sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.56.10':
+    resolution: {integrity: sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.56.10':
+    resolution: {integrity: sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@1.0.2':
+    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.9.0':
+    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@nodeutils/defaults-deep@1.1.0':
     resolution: {integrity: sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==}
 
@@ -795,6 +924,9 @@ packages:
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
+
+  '@types/tinycolor2@1.4.6':
+    resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
@@ -1114,6 +1246,11 @@ packages:
 
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
+
+  cli-ascii-logo@2.1.0:
+    resolution: {integrity: sha512-ziEcQ5/3q8Yx/0nbFe/I22QZTa8+WWUwze9QcfAJEOoINsoCowInN6gBqk5y6zvjW5kp5ZK0EcR1bsvFXdj9LA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -1484,6 +1621,11 @@ packages:
       picomatch:
         optional: true
 
+  figlet@1.10.0:
+    resolution: {integrity: sha512-aktIwEZZ6Gp9AWdMXW4YCi0J2Ahuxo67fNJRUIWD81w8pQ0t9TS8FFpbl27ChlTLF06VkwjDesZSzEVzN75rzA==}
+    engines: {node: '>= 17.0.0'}
+    hasBin: true
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -1590,6 +1732,12 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1616,6 +1764,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gradient-string@3.0.0:
+    resolution: {integrity: sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==}
+    engines: {node: '>=14'}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -1661,6 +1813,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1980,6 +2136,11 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  memfs@4.56.10:
+    resolution: {integrity: sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==}
+    peerDependencies:
+      tslib: '2'
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -2565,11 +2726,20 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thingies@2.5.0:
+    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2582,6 +2752,9 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinygradient@1.1.5:
+    resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
@@ -2593,6 +2766,12 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tree-dump@1.1.0:
+    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3289,6 +3468,133 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.56.10(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.56.10(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.56.10(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.5.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.5.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
   '@nodeutils/defaults-deep@1.1.0':
     dependencies:
       lodash: 4.17.21
@@ -3487,6 +3793,8 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
+
+  '@types/tinycolor2@1.4.6': {}
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3887,6 +4195,13 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.0: {}
+
+  cli-ascii-logo@2.1.0:
+    dependencies:
+      figlet: 1.10.0
+      gradient-string: 3.0.0
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
 
   cli-cursor@3.1.0:
     dependencies:
@@ -4300,6 +4615,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figlet@1.10.0:
+    dependencies:
+      commander: 14.0.3
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -4429,6 +4748,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4461,6 +4784,11 @@ snapshots:
   globals@17.3.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gradient-string@3.0.0:
+    dependencies:
+      chalk: 5.6.2
+      tinygradient: 1.1.5
 
   handlebars@4.7.8:
     dependencies:
@@ -4504,6 +4832,8 @@ snapshots:
   human-signals@8.0.1: {}
 
   husky@9.1.7: {}
+
+  hyperdyperid@1.2.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4787,6 +5117,23 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  memfs@4.56.10(tslib@2.8.1):
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.56.10(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   meow@12.1.1: {}
 
@@ -5391,9 +5738,15 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thingies@2.5.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   through@2.3.8: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -5404,6 +5757,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinygradient@1.1.5:
+    dependencies:
+      '@types/tinycolor2': 1.4.6
+      tinycolor2: 1.6.0
+
   tinyrainbow@3.0.3: {}
 
   tmp@0.0.33:
@@ -5413,6 +5771,10 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tree-dump@1.1.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 

--- a/src/auth/github.test.ts
+++ b/src/auth/github.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRequest = vi.fn();
+const mockReposGet = vi.fn();
+const mockListPackages = vi.fn();
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: class {
+    request = mockRequest;
+    rest = {
+      repos: { get: mockReposGet },
+      packages: { listPackagesForOrganization: mockListPackages },
+    };
+  },
+}));
+
+vi.mock('@clack/prompts', () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('./token-storage.js', () => ({
+  getStoredToken: vi.fn(),
+  saveToken: vi.fn(),
+}));
+
+vi.mock('./prompts.js', () => ({
+  promptForToken: vi.fn(),
+}));
+
+describe('github', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    mockRequest.mockReset();
+    mockReposGet.mockReset();
+    mockListPackages.mockReset();
+  });
+
+  describe('validateToken', () => {
+    it('should return valid result with scopes and username', async () => {
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo, read:packages' },
+      });
+      const { validateToken } = await import('./github.js');
+      const result = await validateToken('ghp_test');
+      expect(result).toEqual({
+        valid: true,
+        scopes: ['repo', 'read:packages'],
+        missingScopes: [],
+        username: 'testuser',
+      });
+    });
+
+    it('should identify missing scopes', async () => {
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo' },
+      });
+      const { validateToken } = await import('./github.js');
+      const result = await validateToken('ghp_test');
+      expect(result.missingScopes).toEqual(['read:packages']);
+    });
+
+    it('should handle empty scopes header', async () => {
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': '' },
+      });
+      const { validateToken } = await import('./github.js');
+      const result = await validateToken('ghp_test');
+      expect(result.missingScopes).toEqual(['repo', 'read:packages']);
+    });
+  });
+
+  describe('checkRepoAccess', () => {
+    it('should return true when repo is accessible', async () => {
+      mockReposGet.mockResolvedValue({ data: {} });
+      const { checkRepoAccess } = await import('./github.js');
+      expect(await checkRepoAccess('ghp_test')).toBe(true);
+    });
+
+    it('should return false when repo is not accessible', async () => {
+      mockReposGet.mockRejectedValue(new Error('Not Found'));
+      const { checkRepoAccess } = await import('./github.js');
+      expect(await checkRepoAccess('ghp_test')).toBe(false);
+    });
+  });
+
+  describe('checkRegistryAccess', () => {
+    it('should return true when registry is accessible', async () => {
+      mockListPackages.mockResolvedValue({ data: [] });
+      const { checkRegistryAccess } = await import('./github.js');
+      expect(await checkRegistryAccess('ghp_test')).toBe(true);
+    });
+
+    it('should return false when registry is not accessible', async () => {
+      mockListPackages.mockRejectedValue(new Error('Forbidden'));
+      const { checkRegistryAccess } = await import('./github.js');
+      expect(await checkRegistryAccess('ghp_test')).toBe(false);
+    });
+  });
+
+  describe('ensureGitHubAuth', () => {
+    it('should use stored token and succeed', async () => {
+      const { getStoredToken, saveToken } = await import('./token-storage.js');
+      (getStoredToken as ReturnType<typeof vi.fn>).mockResolvedValue('ghp_stored');
+      (saveToken as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo, read:packages' },
+      });
+      mockReposGet.mockResolvedValue({ data: {} });
+      mockListPackages.mockResolvedValue({ data: [] });
+
+      const { ensureGitHubAuth } = await import('./github.js');
+      await ensureGitHubAuth();
+      expect(saveToken).toHaveBeenCalledWith('ghp_stored');
+    });
+
+    it('should prompt for token when none stored', async () => {
+      const { getStoredToken, saveToken } = await import('./token-storage.js');
+      const { promptForToken } = await import('./prompts.js');
+      (getStoredToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (promptForToken as ReturnType<typeof vi.fn>).mockResolvedValue('ghp_prompted');
+      (saveToken as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo, read:packages' },
+      });
+      mockReposGet.mockResolvedValue({ data: {} });
+      mockListPackages.mockResolvedValue({ data: [] });
+
+      const { ensureGitHubAuth } = await import('./github.js');
+      await ensureGitHubAuth();
+      expect(promptForToken).toHaveBeenCalled();
+      expect(saveToken).toHaveBeenCalledWith('ghp_prompted');
+    });
+
+    it('should throw on missing scopes', async () => {
+      const { getStoredToken } = await import('./token-storage.js');
+      (getStoredToken as ReturnType<typeof vi.fn>).mockResolvedValue('ghp_limited');
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo' },
+      });
+
+      const { ensureGitHubAuth } = await import('./github.js');
+      await expect(ensureGitHubAuth()).rejects.toThrow('missing required scopes: read:packages');
+    });
+
+    it('should throw when repo is not accessible', async () => {
+      const { getStoredToken } = await import('./token-storage.js');
+      (getStoredToken as ReturnType<typeof vi.fn>).mockResolvedValue('ghp_norepo');
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo, read:packages' },
+      });
+      mockReposGet.mockRejectedValue(new Error('Not Found'));
+
+      const { ensureGitHubAuth } = await import('./github.js');
+      await expect(ensureGitHubAuth()).rejects.toThrow('does not have access to stormreply/innovator-template');
+    });
+
+    it('should throw when registry is not accessible', async () => {
+      const { getStoredToken } = await import('./token-storage.js');
+      (getStoredToken as ReturnType<typeof vi.fn>).mockResolvedValue('ghp_noreg');
+      mockRequest.mockResolvedValue({
+        data: { login: 'testuser' },
+        headers: { 'x-oauth-scopes': 'repo, read:packages' },
+      });
+      mockReposGet.mockResolvedValue({ data: {} });
+      mockListPackages.mockRejectedValue(new Error('Forbidden'));
+
+      const { ensureGitHubAuth } = await import('./github.js');
+      await expect(ensureGitHubAuth()).rejects.toThrow('does not have access to the stormreply package registry');
+    });
+  });
+});

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -1,0 +1,100 @@
+import { Octokit } from '@octokit/rest';
+import * as p from '@clack/prompts';
+import { GITHUB_ORG, TEMPLATE_REPO, REQUIRED_SCOPES } from '../utils/constants.js';
+import { getStoredToken, saveToken } from './token-storage.js';
+import { promptForToken } from './prompts.js';
+
+export interface TokenValidation {
+  valid: boolean;
+  scopes: string[];
+  missingScopes: string[];
+  username: string;
+}
+
+export async function validateToken(token: string): Promise<TokenValidation> {
+  const octokit = new Octokit({ auth: token });
+  const response = await octokit.request('GET /user');
+  const scopeHeader = response.headers['x-oauth-scopes'] ?? '';
+  const scopes = scopeHeader
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const missingScopes = REQUIRED_SCOPES.filter((s) => !scopes.includes(s));
+
+  return {
+    valid: true,
+    scopes,
+    missingScopes,
+    username: response.data.login,
+  };
+}
+
+export async function checkRepoAccess(token: string): Promise<boolean> {
+  const octokit = new Octokit({ auth: token });
+  try {
+    await octokit.rest.repos.get({ owner: GITHUB_ORG, repo: TEMPLATE_REPO });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function checkRegistryAccess(token: string): Promise<boolean> {
+  const octokit = new Octokit({ auth: token });
+  try {
+    await octokit.rest.packages.listPackagesForOrganization({ org: GITHUB_ORG, package_type: 'npm' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureGitHubAuth(): Promise<void> {
+  const s = p.spinner();
+
+  s.start('Reading token from ~/.npmrc');
+  let token = await getStoredToken();
+  if (token) {
+    s.stop('Token found in ~/.npmrc');
+  } else {
+    s.stop('No token found in ~/.npmrc');
+    token = await promptForToken();
+  }
+
+  s.start('Validating token with GitHub');
+  const validation = await validateToken(token);
+  if (validation.missingScopes.length > 0) {
+    s.stop('Token validation failed');
+    throw new Error(
+      `Token for @${validation.username} is missing required scopes: ${validation.missingScopes.join(', ')}.\n` +
+        `Please create a new token at https://github.com/settings/tokens/new with scopes: ${REQUIRED_SCOPES.join(', ')}`,
+    );
+  }
+  s.stop(`Authenticated as @${validation.username}`);
+
+  s.start(`Checking access to ${GITHUB_ORG}/${TEMPLATE_REPO}`);
+  const hasRepoAccess = await checkRepoAccess(token);
+  if (!hasRepoAccess) {
+    s.stop('Repository access denied');
+    throw new Error(
+      `Token for @${validation.username} does not have access to ${GITHUB_ORG}/${TEMPLATE_REPO}.\n` +
+        `Please ensure you are a member of the ${GITHUB_ORG} organization.`,
+    );
+  }
+  s.stop(`Access to ${GITHUB_ORG}/${TEMPLATE_REPO} confirmed`);
+
+  s.start(`Checking access to ${GITHUB_ORG} package registry`);
+  const hasRegistryAccess = await checkRegistryAccess(token);
+  if (!hasRegistryAccess) {
+    s.stop('Registry access denied');
+    throw new Error(
+      `Token for @${validation.username} does not have access to the ${GITHUB_ORG} package registry.\n` +
+        `Please ensure your token has the read:packages scope.`,
+    );
+  }
+  s.stop(`Access to ${GITHUB_ORG} package registry confirmed`);
+
+  s.start('Saving token to ~/.npmrc');
+  await saveToken(token);
+  s.stop('Token saved to ~/.npmrc');
+}

--- a/src/auth/prompts.test.ts
+++ b/src/auth/prompts.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+vi.mock('@clack/prompts', () => ({
+  note: vi.fn(),
+  password: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+}));
+
+describe('prompts', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const prompts = await import('@clack/prompts');
+    (prompts.note as Mock).mockClear();
+    (prompts.password as Mock).mockClear();
+    (prompts.isCancel as Mock).mockReset().mockReturnValue(false);
+    (prompts.cancel as Mock).mockClear();
+  });
+
+  it('should display instructions and return entered token', async () => {
+    const { password } = await import('@clack/prompts');
+    (password as Mock).mockResolvedValue('ghp_user_token');
+
+    const { promptForToken } = await import('./prompts.js');
+    const result = await promptForToken();
+
+    const { note } = await import('@clack/prompts');
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining('https://github.com/settings/tokens/new'),
+      'GitHub Authentication',
+    );
+    expect(result).toBe('ghp_user_token');
+  });
+
+  it('should exit on cancel', async () => {
+    const { password, isCancel } = await import('@clack/prompts');
+    const cancelSymbol = Symbol('cancel');
+    (password as Mock).mockResolvedValue(cancelSymbol);
+    (isCancel as Mock).mockReturnValue(true);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    const { promptForToken } = await import('./prompts.js');
+    await expect(promptForToken()).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+});

--- a/src/auth/prompts.ts
+++ b/src/auth/prompts.ts
@@ -1,0 +1,31 @@
+import * as p from '@clack/prompts';
+import { REQUIRED_SCOPES } from '../utils/constants.js';
+
+export async function promptForToken(): Promise<string> {
+  p.note(
+    [
+      'A GitHub Personal Access Token (PAT) is required to access the template repository and package registry.',
+      '',
+      '1. Go to https://github.com/settings/tokens/new',
+      `2. Select scopes: ${REQUIRED_SCOPES.join(', ')}`,
+      '3. Generate and paste the token below',
+    ].join('\n'),
+    'GitHub Authentication',
+  );
+
+  const token = await p.password({
+    message: 'Enter your GitHub Personal Access Token',
+    validate(value) {
+      if (!value || value.trim().length === 0) {
+        return 'Token is required';
+      }
+    },
+  });
+
+  if (p.isCancel(token)) {
+    p.cancel('Authentication cancelled.');
+    process.exit(0);
+  }
+
+  return token;
+}

--- a/src/auth/token-storage.test.ts
+++ b/src/auth/token-storage.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const NPMRC_PATH = join(homedir(), '.npmrc');
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+describe('token-storage', () => {
+  let readFile: ReturnType<typeof vi.fn>;
+  let writeFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const fs = await import('node:fs/promises');
+    readFile = fs.readFile as ReturnType<typeof vi.fn>;
+    writeFile = fs.writeFile as ReturnType<typeof vi.fn>;
+    readFile.mockReset();
+    writeFile.mockReset();
+  });
+
+  describe('getStoredToken', () => {
+    it('should return token from .npmrc', async () => {
+      readFile.mockResolvedValue('//npm.pkg.github.com/:_authToken=ghp_abc123\n');
+      const { getStoredToken } = await import('./token-storage.js');
+      expect(await getStoredToken()).toBe('ghp_abc123');
+    });
+
+    it('should return null when no token exists', async () => {
+      readFile.mockResolvedValue('registry=https://registry.npmjs.org\n');
+      const { getStoredToken } = await import('./token-storage.js');
+      expect(await getStoredToken()).toBeNull();
+    });
+
+    it('should return null when .npmrc does not exist', async () => {
+      readFile.mockRejectedValue(new Error('ENOENT'));
+      const { getStoredToken } = await import('./token-storage.js');
+      expect(await getStoredToken()).toBeNull();
+    });
+
+    it('should return null for empty token value', async () => {
+      readFile.mockResolvedValue('//npm.pkg.github.com/:_authToken=\n');
+      const { getStoredToken } = await import('./token-storage.js');
+      expect(await getStoredToken()).toBeNull();
+    });
+  });
+
+  describe('saveToken', () => {
+    it('should write token and registry to new .npmrc', async () => {
+      readFile.mockResolvedValue('');
+      writeFile.mockResolvedValue(undefined);
+      const { saveToken } = await import('./token-storage.js');
+      await saveToken('ghp_new123');
+      expect(writeFile).toHaveBeenCalledWith(
+        NPMRC_PATH,
+        expect.stringContaining('//npm.pkg.github.com/:_authToken=ghp_new123'),
+        'utf8',
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        NPMRC_PATH,
+        expect.stringContaining('@stormreply:registry=https://npm.pkg.github.com'),
+        'utf8',
+      );
+    });
+
+    it('should update existing token line', async () => {
+      readFile.mockResolvedValue(
+        '//npm.pkg.github.com/:_authToken=ghp_old\n@stormreply:registry=https://npm.pkg.github.com\n',
+      );
+      writeFile.mockResolvedValue(undefined);
+      const { saveToken } = await import('./token-storage.js');
+      await saveToken('ghp_updated');
+      const written = writeFile.mock.calls[0][1] as string;
+      expect(written).toContain('//npm.pkg.github.com/:_authToken=ghp_updated');
+      expect(written).not.toContain('ghp_old');
+    });
+
+    it('should preserve other .npmrc entries', async () => {
+      readFile.mockResolvedValue('registry=https://registry.npmjs.org\nsome-setting=true\n');
+      writeFile.mockResolvedValue(undefined);
+      const { saveToken } = await import('./token-storage.js');
+      await saveToken('ghp_test');
+      const written = writeFile.mock.calls[0][1] as string;
+      expect(written).toContain('registry=https://registry.npmjs.org');
+      expect(written).toContain('some-setting=true');
+    });
+  });
+});

--- a/src/auth/token-storage.ts
+++ b/src/auth/token-storage.ts
@@ -1,0 +1,58 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { GITHUB_ORG, GITHUB_REGISTRY_URL } from '../utils/constants.js';
+
+const NPMRC_PATH = join(homedir(), '.npmrc');
+const AUTH_TOKEN_LINE = `//npm.pkg.github.com/:_authToken=`;
+const REGISTRY_LINE = `@${GITHUB_ORG}:registry=${GITHUB_REGISTRY_URL}`;
+
+async function readNpmrc(): Promise<string> {
+  try {
+    return await readFile(NPMRC_PATH, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+export async function getStoredToken(): Promise<string | null> {
+  const content = await readNpmrc();
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(AUTH_TOKEN_LINE)) {
+      const token = trimmed.slice(AUTH_TOKEN_LINE.length);
+      if (token) return token;
+    }
+  }
+  return null;
+}
+
+export async function saveToken(token: string): Promise<void> {
+  const content = await readNpmrc();
+  const lines = content.split('\n');
+
+  let hasAuthToken = false;
+  let hasRegistry = false;
+
+  const updated = lines.map((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(AUTH_TOKEN_LINE)) {
+      hasAuthToken = true;
+      return `${AUTH_TOKEN_LINE}${token}`;
+    }
+    if (trimmed === REGISTRY_LINE) {
+      hasRegistry = true;
+    }
+    return line;
+  });
+
+  if (!hasAuthToken) {
+    updated.push(`${AUTH_TOKEN_LINE}${token}`);
+  }
+  if (!hasRegistry) {
+    updated.push(REGISTRY_LINE);
+  }
+
+  const result = updated.filter((line, i) => !(line === '' && i === updated.length - 1)).join('\n');
+  await writeFile(NPMRC_PATH, result.endsWith('\n') ? result : result + '\n', 'utf8');
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -22,7 +22,23 @@ vi.mock('@clack/prompts', () => ({
   intro: vi.fn(),
   text: vi.fn(),
   outro: vi.fn(),
+  log: { error: vi.fn() },
   isCancel: vi.fn(() => false),
+}));
+
+vi.mock('./auth/github.js', () => ({
+  ensureGitHubAuth: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./scaffold/clone.js', () => ({
+  ensureGhCli: vi.fn().mockResolvedValue(undefined),
+  cloneTemplate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./scaffold/template.js', () => ({
+  readManifest: vi.fn().mockResolvedValue({ placeholders: [], files: [], exclude: [] }),
+  collectValues: vi.fn().mockResolvedValue({}),
+  applyReplacements: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('cli', () => {
@@ -76,7 +92,7 @@ describe('cli', () => {
     const { text, outro } = await import('@clack/prompts');
     await capturedCommand.run({ args: { name: 'cool-project' } });
     expect(text).not.toHaveBeenCalled();
-    expect(outro).toHaveBeenCalledWith('Scaffolding cool-project...');
+    expect(outro).toHaveBeenCalledWith('Project cool-project is ready!');
   });
 
   it('should prompt for project name when no name given', async () => {
@@ -88,7 +104,7 @@ describe('cli', () => {
       defaultValue: 'my-innovator-app',
       placeholder: 'my-innovator-app',
     });
-    expect(outro).toHaveBeenCalledWith('Scaffolding my-innovator-app...');
+    expect(outro).toHaveBeenCalledWith('Project my-innovator-app is ready!');
   });
 
   it('should exit on cancel', async () => {

--- a/src/scaffold/clone.test.ts
+++ b/src/scaffold/clone.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecFile = vi.fn();
+const mockAccess = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+    const result = mockExecFile(args[0], args[1]);
+    if (result instanceof Error) {
+      cb(result, { stdout: '', stderr: '' });
+    } else {
+      cb(null, { stdout: '', stderr: '' });
+    }
+  },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  access: (...args: unknown[]) => mockAccess(...args),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+describe('clone', () => {
+  beforeEach(() => {
+    mockExecFile.mockReset();
+    mockAccess.mockReset();
+  });
+
+  describe('ensureGhCli', () => {
+    it('should succeed when gh is available', async () => {
+      mockExecFile.mockReturnValue(undefined);
+      const { ensureGhCli } = await import('./clone.js');
+      await expect(ensureGhCli()).resolves.toBeUndefined();
+      expect(mockExecFile).toHaveBeenCalledWith('gh', ['--version']);
+    });
+
+    it('should throw when gh is not installed', async () => {
+      mockExecFile.mockReturnValue(new Error('not found'));
+      const { ensureGhCli } = await import('./clone.js');
+      await expect(ensureGhCli()).rejects.toThrow('GitHub CLI (gh) is not installed');
+    });
+  });
+
+  describe('cloneTemplate', () => {
+    it('should throw when directory already exists', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      const { cloneTemplate } = await import('./clone.js');
+      await expect(cloneTemplate('existing-dir')).rejects.toThrow('already exists');
+    });
+
+    it('should clone, remove .git, and init new repo', async () => {
+      mockAccess.mockRejectedValue(new Error('ENOENT'));
+      mockExecFile.mockReturnValue(undefined);
+      const { cloneTemplate } = await import('./clone.js');
+      await cloneTemplate('my-project');
+      expect(mockExecFile).toHaveBeenCalledWith('gh', ['repo', 'clone', 'stormreply/innovator-template', 'my-project']);
+      expect(mockExecFile).toHaveBeenCalledWith('rm', ['-rf', 'my-project/.git']);
+      expect(mockExecFile).toHaveBeenCalledWith('git', ['init', 'my-project']);
+    });
+  });
+});

--- a/src/scaffold/clone.ts
+++ b/src/scaffold/clone.ts
@@ -1,0 +1,37 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { access } from 'node:fs/promises';
+import * as p from '@clack/prompts';
+import { GITHUB_ORG, TEMPLATE_REPO } from '../utils/constants.js';
+
+const execFile = promisify(execFileCb);
+
+export async function ensureGhCli(): Promise<void> {
+  try {
+    await execFile('gh', ['--version']);
+  } catch {
+    throw new Error(
+      'GitHub CLI (gh) is not installed.\n' + 'Please install it from https://cli.github.com and try again.',
+    );
+  }
+}
+
+export async function cloneTemplate(name: string): Promise<void> {
+  try {
+    await access(name);
+    throw new Error(`Directory "${name}" already exists. Please choose a different project name.`);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('already exists')) throw err;
+  }
+
+  const s = p.spinner();
+
+  s.start(`Cloning ${GITHUB_ORG}/${TEMPLATE_REPO}`);
+  await execFile('gh', ['repo', 'clone', `${GITHUB_ORG}/${TEMPLATE_REPO}`, name]);
+  s.stop(`Cloned ${GITHUB_ORG}/${TEMPLATE_REPO}`);
+
+  s.start('Initializing fresh git repository');
+  await execFile('rm', ['-rf', `${name}/.git`]);
+  await execFile('git', ['init', name]);
+  s.stop('Git repository initialized');
+}

--- a/src/scaffold/template.test.ts
+++ b/src/scaffold/template.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { vol } from 'memfs';
+
+vi.mock('node:fs/promises', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs.promises;
+});
+
+vi.mock('@clack/prompts', () => ({
+  text: vi.fn(),
+  isCancel: vi.fn(() => false),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+describe('template', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  describe('readManifest', () => {
+    it('should read and parse template.config.json', async () => {
+      const config = {
+        placeholders: [{ key: 'PROJECT_NAME', prompt: 'Project name' }],
+        files: ['*.ts'],
+        exclude: ['node_modules'],
+      };
+      vol.fromJSON({ '/project/template.config.json': JSON.stringify(config) });
+
+      const { readManifest } = await import('./template.js');
+      const result = await readManifest('/project');
+      expect(result).toEqual(config);
+    });
+
+    it('should throw when template.config.json is missing', async () => {
+      vol.fromJSON({});
+      const { readManifest } = await import('./template.js');
+      await expect(readManifest('/project')).rejects.toThrow();
+    });
+  });
+
+  describe('collectValues', () => {
+    it('should use defaults without prompting', async () => {
+      const placeholders = [{ key: 'PROJECT_NAME', prompt: 'Project name' }];
+      const { collectValues } = await import('./template.js');
+      const result = await collectValues(placeholders, { PROJECT_NAME: 'my-app' });
+      expect(result).toEqual({ PROJECT_NAME: 'my-app' });
+
+      const { text } = await import('@clack/prompts');
+      expect(text).not.toHaveBeenCalled();
+    });
+
+    it('should prompt for values not in defaults', async () => {
+      const { text } = await import('@clack/prompts');
+      (text as ReturnType<typeof vi.fn>).mockResolvedValue('Storm Reply');
+
+      const placeholders = [{ key: 'ORG_NAME', prompt: 'Organization name' }];
+      const { collectValues } = await import('./template.js');
+      const result = await collectValues(placeholders);
+      expect(result).toEqual({ ORG_NAME: 'Storm Reply' });
+    });
+
+    it('should throw when user cancels', async () => {
+      const { text, isCancel } = await import('@clack/prompts');
+      (text as ReturnType<typeof vi.fn>).mockResolvedValue(Symbol('cancel'));
+      (isCancel as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const placeholders = [{ key: 'NAME', prompt: 'Name' }];
+      const { collectValues } = await import('./template.js');
+      await expect(collectValues(placeholders)).rejects.toThrow('Value for "NAME" is required');
+    });
+  });
+
+  describe('applyReplacements', () => {
+    it('should replace placeholders in matching files', async () => {
+      vol.fromJSON({
+        '/project/src/index.ts': 'console.log("{{PROJECT_NAME}}")',
+        '/project/template.config.json': '{}',
+      });
+
+      const config = {
+        placeholders: [],
+        files: ['*.ts'],
+        exclude: ['node_modules'],
+      };
+
+      const { applyReplacements } = await import('./template.js');
+      await applyReplacements('/project', config, { PROJECT_NAME: 'cool-app' });
+
+      const content = vol.readFileSync('/project/src/index.ts', 'utf8');
+      expect(content).toBe('console.log("cool-app")');
+    });
+
+    it('should remove template.config.json after replacement', async () => {
+      vol.fromJSON({
+        '/project/readme.md': '# {{PROJECT_NAME}}',
+        '/project/template.config.json': '{}',
+      });
+
+      const config = {
+        placeholders: [],
+        files: ['*.md'],
+        exclude: [],
+      };
+
+      const { applyReplacements } = await import('./template.js');
+      await applyReplacements('/project', config, { PROJECT_NAME: 'my-app' });
+
+      expect(() => vol.readFileSync('/project/template.config.json')).toThrow();
+    });
+
+    it('should skip excluded files', async () => {
+      vol.fromJSON({
+        '/project/node_modules/pkg/index.ts': '{{PROJECT_NAME}}',
+        '/project/src/index.ts': '{{PROJECT_NAME}}',
+        '/project/template.config.json': '{}',
+      });
+
+      const config = {
+        placeholders: [],
+        files: ['*.ts'],
+        exclude: ['node_modules'],
+      };
+
+      const { applyReplacements } = await import('./template.js');
+      await applyReplacements('/project', config, { PROJECT_NAME: 'app' });
+
+      expect(vol.readFileSync('/project/node_modules/pkg/index.ts', 'utf8')).toBe('{{PROJECT_NAME}}');
+      expect(vol.readFileSync('/project/src/index.ts', 'utf8')).toBe('app');
+    });
+  });
+});

--- a/src/scaffold/template.ts
+++ b/src/scaffold/template.ts
@@ -1,0 +1,109 @@
+import { readFile, writeFile, readdir, rm } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import * as p from '@clack/prompts';
+
+export interface Placeholder {
+  key: string;
+  prompt: string;
+  transform?: string;
+}
+
+export interface TemplateConfig {
+  placeholders: Placeholder[];
+  files: string[];
+  exclude: string[];
+}
+
+export async function readManifest(dir: string): Promise<TemplateConfig> {
+  const configPath = join(dir, 'template.config.json');
+  const raw = await readFile(configPath, 'utf8');
+  return JSON.parse(raw) as TemplateConfig;
+}
+
+export async function collectValues(
+  placeholders: Placeholder[],
+  defaults: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  const values: Record<string, string> = {};
+
+  for (const ph of placeholders) {
+    if (defaults[ph.key] !== undefined) {
+      values[ph.key] = defaults[ph.key];
+      continue;
+    }
+
+    const value = await p.text({
+      message: ph.prompt,
+      placeholder: ph.key,
+    });
+
+    if (p.isCancel(value) || !value) {
+      throw new Error(`Value for "${ph.key}" is required. Aborting.`);
+    }
+
+    values[ph.key] = value;
+  }
+
+  return values;
+}
+
+function matchesPattern(filePath: string, pattern: string): boolean {
+  if (pattern.startsWith('*')) {
+    return filePath.endsWith(pattern.slice(1));
+  }
+  return filePath.includes(pattern);
+}
+
+function isBinaryBuffer(buffer: Buffer): boolean {
+  for (let i = 0; i < Math.min(buffer.length, 8000); i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+export async function applyReplacements(
+  dir: string,
+  config: TemplateConfig,
+  values: Record<string, string>,
+): Promise<void> {
+  const s = p.spinner();
+  s.start('Replacing placeholders');
+
+  const allFiles = await readdir(dir, { recursive: true, withFileTypes: true });
+  const files = allFiles.filter((f) => f.isFile()).map((f) => relative(dir, join(f.parentPath, f.name)));
+
+  const matchingFiles = files.filter((f) => {
+    const excluded = config.exclude.some((pattern) => matchesPattern(f, pattern));
+    if (excluded) return false;
+    return config.files.some((pattern) => matchesPattern(f, pattern));
+  });
+
+  let replacedCount = 0;
+
+  for (const file of matchingFiles) {
+    const filePath = join(dir, file);
+    const buffer = await readFile(filePath);
+
+    if (isBinaryBuffer(buffer)) continue;
+
+    let content = buffer.toString('utf8');
+    let changed = false;
+
+    for (const [key, value] of Object.entries(values)) {
+      const placeholder = `{{${key}}}`;
+      if (content.includes(placeholder)) {
+        content = content.replaceAll(placeholder, value);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await writeFile(filePath, content, 'utf8');
+      replacedCount++;
+    }
+  }
+
+  s.stop(`Replaced placeholders in ${replacedCount} file(s)`);
+
+  await rm(join(dir, 'template.config.json'), { force: true });
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,5 @@
+export const GITHUB_API_BASE = 'https://api.github.com';
+export const GITHUB_ORG = 'stormreply';
+export const TEMPLATE_REPO = 'innovator-template';
+export const REQUIRED_SCOPES = ['repo', 'read:packages'] as const;
+export const GITHUB_REGISTRY_URL = 'https://npm.pkg.github.com';


### PR DESCRIPTION
## Summary
- Clone `stormreply/innovator-template` via `gh repo clone`, reset git history (`.git` → `git init`)
- Replace `{{KEY}}` placeholders in file contents based on `template.config.json` manifest
- Integrate scaffold pipeline into CLI after GitHub authentication: gh check → clone → read manifest → collect values → apply replacements

## New modules
- `src/scaffold/clone.ts` — `ensureGhCli()` + `cloneTemplate(name)`
- `src/scaffold/template.ts` — `readManifest()` + `collectValues()` + `applyReplacements()`
- Full test coverage for both modules (12 new tests)

## Test plan
- [x] `pnpm test` — 41 tests passing
- [x] `pnpm build` — build succeeds
- [x] `pnpm lint` (src/) — no lint errors
- [ ] Manual: run `create-innovator` with a valid GitHub token and verify template clone + placeholder replacement

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)