### PR TITLE
feat: add template version selection with experimental flag

### DIFF
--- a/src/auth/github.test.ts
+++ b/src/auth/github.test.ts
@@ -116,7 +116,8 @@ describe('github', () => {
       mockListPackages.mockResolvedValue({ data: [] });
 
       const { ensureGitHubAuth } = await import('./github.js');
-      await ensureGitHubAuth();
+      const token = await ensureGitHubAuth();
+      expect(token).toBe('ghp_stored');
       expect(saveToken).toHaveBeenCalledWith('ghp_stored');
     });
 
@@ -134,7 +135,8 @@ describe('github', () => {
       mockListPackages.mockResolvedValue({ data: [] });
 
       const { ensureGitHubAuth } = await import('./github.js');
-      await ensureGitHubAuth();
+      const token = await ensureGitHubAuth();
+      expect(token).toBe('ghp_prompted');
       expect(promptForToken).toHaveBeenCalled();
       expect(saveToken).toHaveBeenCalledWith('ghp_prompted');
     });

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -49,7 +49,7 @@ export async function checkRegistryAccess(token: string): Promise<boolean> {
   }
 }
 
-export async function ensureGitHubAuth(): Promise<void> {
+export async function ensureGitHubAuth(): Promise<string> {
   const s = p.spinner();
 
   s.start('Reading token from ~/.npmrc');
@@ -97,4 +97,6 @@ export async function ensureGitHubAuth(): Promise<void> {
   s.start('Saving token to ~/.npmrc');
   await saveToken(token);
   s.stop('Token saved to ~/.npmrc');
+
+  return token;
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -27,11 +27,12 @@ vi.mock('@clack/prompts', () => ({
 }));
 
 vi.mock('./auth/github.js', () => ({
-  ensureGitHubAuth: vi.fn().mockResolvedValue(undefined),
+  ensureGitHubAuth: vi.fn().mockResolvedValue('ghp_mock_token'),
 }));
 
 vi.mock('./scaffold/clone.js', () => ({
   ensureGhCli: vi.fn().mockResolvedValue(undefined),
+  selectVersion: vi.fn().mockResolvedValue('release-v1.0.0'),
   cloneTemplate: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -66,13 +67,20 @@ describe('cli', () => {
     expect(capturedCommand.meta.version).toBe('1.2.3');
   });
 
-  it('should define a name argument as optional string', () => {
+  it('should define name and experimental arguments', () => {
     expect(capturedCommand.args).toEqual({
       name: {
         alias: ['n'],
         description: 'Project name',
         required: false,
         type: 'string',
+      },
+      experimental: {
+        alias: ['e'],
+        description: 'Include experimental (pre-release) versions',
+        required: false,
+        type: 'boolean',
+        default: false,
       },
     });
   });

--- a/src/scaffold/clone.test.ts
+++ b/src/scaffold/clone.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockExecFile = vi.fn();
 const mockAccess = vi.fn();
+const mockPaginateIterator = vi.fn();
+const mockSelect = vi.fn();
 
 vi.mock('node:child_process', () => ({
   execFile: (...args: unknown[]) => {
@@ -19,17 +21,28 @@ vi.mock('node:fs/promises', () => ({
   access: (...args: unknown[]) => mockAccess(...args),
 }));
 
+vi.mock('@octokit/rest', () => ({
+  Octokit: class {
+    paginate = { iterator: mockPaginateIterator };
+    rest = { repos: { listTags: vi.fn() } };
+  },
+}));
+
 vi.mock('@clack/prompts', () => ({
   spinner: vi.fn(() => ({
     start: vi.fn(),
     stop: vi.fn(),
   })),
+  select: (...args: unknown[]) => mockSelect(...args),
+  isCancel: (v: unknown) => v === Symbol.for('cancel'),
 }));
 
 describe('clone', () => {
   beforeEach(() => {
     mockExecFile.mockReset();
     mockAccess.mockReset();
+    mockPaginateIterator.mockReset();
+    mockSelect.mockReset();
   });
 
   describe('ensureGhCli', () => {
@@ -47,6 +60,67 @@ describe('clone', () => {
     });
   });
 
+  describe('fetchReleaseTags', () => {
+    it('should return only tags starting with release-v by default', async () => {
+      mockPaginateIterator.mockReturnValue(
+        (async function* () {
+          yield {
+            data: [{ name: 'release-v1.0.0' }, { name: 'release-v2.0.0' }, { name: 'v0.5.0' }, { name: 'other-tag' }],
+          };
+        })(),
+      );
+      const { fetchReleaseTags } = await import('./clone.js');
+      const tags = await fetchReleaseTags('ghp_test');
+      expect(tags).toEqual(['release-v1.0.0', 'release-v2.0.0']);
+    });
+
+    it('should include experimental tags when flag is set', async () => {
+      mockPaginateIterator.mockReturnValue(
+        (async function* () {
+          yield { data: [{ name: 'release-v1.0.0' }, { name: 'v0.5.0' }, { name: 'v0.4.0' }, { name: 'other-tag' }] };
+        })(),
+      );
+      const { fetchReleaseTags } = await import('./clone.js');
+      const tags = await fetchReleaseTags('ghp_test', true);
+      expect(tags).toEqual(['release-v1.0.0', 'v0.5.0', 'v0.4.0']);
+    });
+
+    it('should return empty array when no matching tags', async () => {
+      mockPaginateIterator.mockReturnValue(
+        (async function* () {
+          yield { data: [{ name: 'other-tag' }] };
+        })(),
+      );
+      const { fetchReleaseTags } = await import('./clone.js');
+      const tags = await fetchReleaseTags('ghp_test');
+      expect(tags).toEqual([]);
+    });
+  });
+
+  describe('selectVersion', () => {
+    it('should throw when no release tags exist', async () => {
+      mockPaginateIterator.mockReturnValue(
+        (async function* () {
+          yield { data: [] };
+        })(),
+      );
+      const { selectVersion } = await import('./clone.js');
+      await expect(selectVersion('ghp_test')).rejects.toThrow('No release tags found');
+    });
+
+    it('should return the selected tag', async () => {
+      mockPaginateIterator.mockReturnValue(
+        (async function* () {
+          yield { data: [{ name: 'release-v2.0.0' }, { name: 'release-v1.0.0' }] };
+        })(),
+      );
+      mockSelect.mockResolvedValue('release-v1.0.0');
+      const { selectVersion } = await import('./clone.js');
+      const result = await selectVersion('ghp_test');
+      expect(result).toBe('release-v1.0.0');
+    });
+  });
+
   describe('cloneTemplate', () => {
     it('should throw when directory already exists', async () => {
       mockAccess.mockResolvedValue(undefined);
@@ -54,14 +128,40 @@ describe('clone', () => {
       await expect(cloneTemplate('existing-dir')).rejects.toThrow('already exists');
     });
 
-    it('should clone, remove .git, and init new repo', async () => {
+    it('should shallow clone with tag, remove .git, and init new repo', async () => {
+      mockAccess.mockRejectedValue(new Error('ENOENT'));
+      mockExecFile.mockReturnValue(undefined);
+      const { cloneTemplate } = await import('./clone.js');
+      await cloneTemplate('my-project', 'release-v1.0.0');
+      expect(mockExecFile).toHaveBeenCalledWith('gh', [
+        'repo',
+        'clone',
+        'stormreply/innovator-template',
+        'my-project',
+        '--',
+        '--depth',
+        '1',
+        '--branch',
+        'release-v1.0.0',
+      ]);
+      expect(mockExecFile).toHaveBeenCalledWith('rm', ['-rf', 'my-project/.git']);
+      expect(mockExecFile).toHaveBeenCalledWith('git', ['init', 'my-project']);
+    });
+
+    it('should clone without tag when none provided', async () => {
       mockAccess.mockRejectedValue(new Error('ENOENT'));
       mockExecFile.mockReturnValue(undefined);
       const { cloneTemplate } = await import('./clone.js');
       await cloneTemplate('my-project');
-      expect(mockExecFile).toHaveBeenCalledWith('gh', ['repo', 'clone', 'stormreply/innovator-template', 'my-project']);
-      expect(mockExecFile).toHaveBeenCalledWith('rm', ['-rf', 'my-project/.git']);
-      expect(mockExecFile).toHaveBeenCalledWith('git', ['init', 'my-project']);
+      expect(mockExecFile).toHaveBeenCalledWith('gh', [
+        'repo',
+        'clone',
+        'stormreply/innovator-template',
+        'my-project',
+        '--',
+        '--depth',
+        '1',
+      ]);
     });
   });
 });

--- a/src/scaffold/clone.ts
+++ b/src/scaffold/clone.ts
@@ -1,10 +1,14 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { access } from 'node:fs/promises';
+import { Octokit } from '@octokit/rest';
 import * as p from '@clack/prompts';
 import { GITHUB_ORG, TEMPLATE_REPO } from '../utils/constants.js';
 
 const execFile = promisify(execFileCb);
+
+const TAG_PREFIX_STABLE = 'release-v';
+const TAG_PREFIX_EXPERIMENTAL = 'v';
 
 export async function ensureGhCli(): Promise<void> {
   try {
@@ -16,7 +20,55 @@ export async function ensureGhCli(): Promise<void> {
   }
 }
 
-export async function cloneTemplate(name: string): Promise<void> {
+export async function fetchReleaseTags(token: string, includeExperimental = false): Promise<string[]> {
+  const octokit = new Octokit({ auth: token });
+  const tags: string[] = [];
+
+  for await (const response of octokit.paginate.iterator(octokit.rest.repos.listTags, {
+    owner: GITHUB_ORG,
+    repo: TEMPLATE_REPO,
+    per_page: 100,
+  })) {
+    for (const tag of response.data) {
+      if (tag.name.startsWith(TAG_PREFIX_STABLE)) {
+        tags.push(tag.name);
+      } else if (includeExperimental && tag.name.startsWith(TAG_PREFIX_EXPERIMENTAL)) {
+        tags.push(tag.name);
+      }
+    }
+  }
+
+  return tags;
+}
+
+export async function selectVersion(token: string, includeExperimental = false): Promise<string> {
+  const s = p.spinner();
+  s.start('Fetching available template versions');
+  const tags = await fetchReleaseTags(token, includeExperimental);
+  s.stop(`Found ${tags.length} version(s)`);
+
+  if (tags.length === 0) {
+    throw new Error(`No release tags found in ${GITHUB_ORG}/${TEMPLATE_REPO}.`);
+  }
+
+  const selected = await p.select({
+    message: 'Select a template version',
+    options: tags.map((tag, i) => ({
+      value: tag,
+      label: tag,
+      hint: i === 0 ? 'latest' : !tag.startsWith(TAG_PREFIX_STABLE) ? 'experimental' : undefined,
+    })),
+    initialValue: tags[0],
+  });
+
+  if (p.isCancel(selected)) {
+    process.exit(0);
+  }
+
+  return selected;
+}
+
+export async function cloneTemplate(name: string, tag?: string): Promise<void> {
   try {
     await access(name);
     throw new Error(`Directory "${name}" already exists. Please choose a different project name.`);
@@ -26,9 +78,14 @@ export async function cloneTemplate(name: string): Promise<void> {
 
   const s = p.spinner();
 
-  s.start(`Cloning ${GITHUB_ORG}/${TEMPLATE_REPO}`);
-  await execFile('gh', ['repo', 'clone', `${GITHUB_ORG}/${TEMPLATE_REPO}`, name]);
-  s.stop(`Cloned ${GITHUB_ORG}/${TEMPLATE_REPO}`);
+  const label = tag ? `${GITHUB_ORG}/${TEMPLATE_REPO}@${tag}` : `${GITHUB_ORG}/${TEMPLATE_REPO}`;
+  s.start(`Cloning ${label}`);
+
+  const ghArgs = ['repo', 'clone', `${GITHUB_ORG}/${TEMPLATE_REPO}`, name, '--', '--depth', '1'];
+  if (tag) ghArgs.push('--branch', tag);
+
+  await execFile('gh', ghArgs);
+  s.stop(`Cloned ${label}`);
 
   s.start('Initializing fresh git repository');
   await execFile('rm', ['-rf', `${name}/.git`]);


### PR DESCRIPTION
## Summary
- Add interactive version selection prompt that lists available template tags (`release-v*`) via Octokit API
- Add `--experimental` / `-e` CLI flag to additionally include pre-release versions (`v*` tags) in the selection
- Switch to shallow clone (`--depth 1`) with the selected tag for faster cloning
- `ensureGitHubAuth()` now returns the token for reuse in API calls

## Test plan
- [ ] Run `npx create-innovator` and verify the version selection prompt appears with `release-v*` tags
- [ ] Run `npx create-innovator --experimental` and verify both stable and experimental tags are listed
- [ ] Verify experimental tags show "experimental" hint in the selection
- [ ] Verify the latest version is pre-selected by default
- [ ] Verify cancelling the version selection exits gracefully
- [ ] All 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)