### PR TITLE
chore: use GitHub App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,25 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           fetch-depth: 0
       - name: Setup pnpm package manager
         uses: pnpm/action-setup@v4
@@ -23,10 +39,6 @@ jobs:
           cache: 'pnpm'
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - name: Configure Git
-        run: |
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm release --ci


### PR DESCRIPTION
## Summary
- Replace `github-actions[bot]` with a dedicated GitHub App token for the release workflow
- Generate app token using `actions/create-github-app-token@v2` with configurable App ID and private key
- Configure git user identity from the app's bot account to ensure release commits can trigger subsequent workflows

## Test plan
- [ ] Verify `RELEASE_BOT_APP_ID` variable and `RELEASE_BOT_APP_PRIVATE_KEY` secret are configured in repository settings
- [ ] Trigger a release and confirm the commit is authored by the app bot
- [ ] Confirm subsequent workflows (e.g., publish) are triggered by the release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)