### PR TITLE
fix: use app token for release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,5 @@ jobs:
       - run: pnpm build
       - run: pnpm release --ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0


### PR DESCRIPTION
## Summary
- The previous commit (`2ca5098`) added GitHub App token generation to the release workflow but missed updating the `pnpm release` step
- This fixes the `GITHUB_TOKEN` env var to use `steps.app-token.outputs.token` instead of `secrets.GITHUB_TOKEN`, ensuring release commits are pushed with the App token and can trigger subsequent workflows

## Test plan
- [ ] Verify the release workflow runs successfully with the corrected token

🤖 Generated with [Claude Code](https://claude.com/claude-code)