### PR TITLE
fix: persist app token credentials in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
           fetch-depth: 0
       - name: Setup pnpm package manager
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from the checkout step so the GitHub App token remains available for git push operations during the release process
- Without this fix, the release step cannot push commits because the token is discarded after checkout

## Test plan
- [ ] Trigger a release and verify the release commit is pushed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)