### PR TITLE
feat: automate post-clone project setup

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -40,6 +40,10 @@ vi.mock('./scaffold/template.js', () => ({
   replaceTemplateNames: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./scaffold/setup.js', () => ({
+  setupProject: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('cli', () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -111,6 +115,13 @@ describe('cli', () => {
       placeholder: 'my-innovator-app',
     });
     expect(outro).toHaveBeenCalledWith('Project my-innovator-app is ready!');
+  });
+
+  it('should call setupProject with project name after template replacement', async () => {
+    const { setupProject } = await import('./scaffold/setup.js');
+    (setupProject as Mock).mockClear();
+    await capturedCommand.run({ args: { name: 'cool-project' } });
+    expect(setupProject).toHaveBeenCalledWith('cool-project');
   });
 
   it('should exit on cancel', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { intro, text, isCancel, outro, log } from '@clack/prompts';
 import { ensureGitHubAuth } from './auth/github.js';
 import { ensureGhCli, cloneTemplate, selectVersion } from './scaffold/clone.js';
 import { replaceTemplateNames } from './scaffold/template.js';
+import { setupProject } from './scaffold/setup.js';
 
 const pkgUrl = new URL('../package.json', import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgUrl, 'utf8')) as { version?: string };
@@ -58,6 +59,8 @@ const main = defineCommand({
       log.error(error instanceof Error ? error.message : 'Scaffolding failed.');
       process.exit(1);
     }
+
+    await setupProject(projectName);
 
     outro(`Project ${projectName} is ready!`);
   },

--- a/src/scaffold/setup.test.ts
+++ b/src/scaffold/setup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecFile = vi.fn();
+const mockSpinner = { start: vi.fn(), stop: vi.fn(), message: vi.fn() };
+const mockLogWarn = vi.fn();
+const mockLogInfo = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => {
+    const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+    const result = mockExecFile(args[0], args[1], args[2]);
+    if (result instanceof Error) {
+      cb(result, { stdout: '', stderr: '' });
+    } else {
+      cb(null, { stdout: '', stderr: '' });
+    }
+  },
+}));
+
+vi.mock('@clack/prompts', () => ({
+  spinner: vi.fn(() => mockSpinner),
+  log: { warn: (...args: unknown[]) => mockLogWarn(...args), info: (...args: unknown[]) => mockLogInfo(...args) },
+}));
+
+describe('setupProject', () => {
+  beforeEach(() => {
+    mockExecFile.mockReset();
+    mockSpinner.start.mockReset();
+    mockSpinner.stop.mockReset();
+    mockSpinner.message.mockReset();
+    mockLogWarn.mockReset();
+    mockLogInfo.mockReset();
+  });
+
+  it('should skip corepack enable when pnpm is already available', async () => {
+    mockExecFile.mockReturnValue(undefined);
+    const { setupProject } = await import('./setup.js');
+    await setupProject('my-project');
+    expect(mockExecFile).toHaveBeenCalledWith('pnpm', ['--version'], expect.any(Function));
+    expect(mockExecFile).not.toHaveBeenCalledWith('corepack', expect.anything(), expect.anything());
+    expect(mockExecFile).toHaveBeenCalledWith('pnpm', ['install'], { cwd: 'my-project' });
+    expect(mockExecFile).toHaveBeenCalledWith('pnpm', ['test', '-u'], { cwd: 'my-project' });
+  });
+
+  it('should run corepack enable when pnpm is not available', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm' && args[0] === '--version') return new Error('not found');
+      return undefined;
+    });
+    const { setupProject } = await import('./setup.js');
+    await setupProject('my-project');
+    expect(mockExecFile).toHaveBeenCalledWith('corepack', ['enable'], expect.any(Function));
+    expect(mockExecFile).toHaveBeenCalledWith('pnpm', ['install'], { cwd: 'my-project' });
+  });
+
+  it('should warn when corepack enable fails', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm' && args[0] === '--version') return new Error('not found');
+      if (cmd === 'corepack') return new Error('corepack failed');
+      return undefined;
+    });
+    const { setupProject } = await import('./setup.js');
+    await setupProject('my-project');
+    expect(mockLogWarn).toHaveBeenCalled();
+    expect(mockLogInfo).toHaveBeenCalled();
+  });
+
+  it('should warn when pnpm install fails', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm' && args[0] === 'install') return new Error('install failed');
+      return undefined;
+    });
+    const { setupProject } = await import('./setup.js');
+    await setupProject('my-project');
+    expect(mockLogWarn).toHaveBeenCalled();
+    expect(mockLogInfo).toHaveBeenCalled();
+  });
+
+  it('should warn when pnpm test fails', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm' && args[0] === 'test') return new Error('test failed');
+      return undefined;
+    });
+    const { setupProject } = await import('./setup.js');
+    await setupProject('my-project');
+    expect(mockLogWarn).toHaveBeenCalled();
+    expect(mockLogInfo).toHaveBeenCalled();
+  });
+
+  it('should never reject', async () => {
+    mockExecFile.mockReturnValue(new Error('everything fails'));
+    const { setupProject } = await import('./setup.js');
+    await expect(setupProject('my-project')).resolves.toBeUndefined();
+  });
+});

--- a/src/scaffold/setup.ts
+++ b/src/scaffold/setup.ts
@@ -1,0 +1,32 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as p from '@clack/prompts';
+
+const execFile = promisify(execFileCb);
+
+export async function setupProject(projectDir: string): Promise<void> {
+  const s = p.spinner();
+
+  try {
+    s.start('Checking pnpm availability');
+    try {
+      await execFile('pnpm', ['--version']);
+    } catch {
+      s.message('Enabling corepack');
+      await execFile('corepack', ['enable']);
+    }
+    s.stop('pnpm is available');
+
+    s.start('Installing dependencies');
+    await execFile('pnpm', ['install'], { cwd: projectDir });
+    s.stop('Dependencies installed');
+
+    s.start('Updating test snapshots');
+    await execFile('pnpm', ['test', '-u'], { cwd: projectDir });
+    s.stop('Test snapshots updated');
+  } catch {
+    s.stop('Setup incomplete');
+    p.log.warn('Automatic setup failed. Run these commands manually:');
+    p.log.info(`  cd ${projectDir}\n  corepack enable\n  pnpm install\n  pnpm test -u`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add automatic post-clone setup that installs dependencies via pnpm and updates test snapshots after scaffolding
- Setup failures are non-fatal — the CLI warns with manual recovery steps instead of aborting
- Checks pnpm availability first, falling back to `corepack enable` if needed

Closes #9

## Test plan

- [x] `pnpm test` — all 53 tests pass (6 new tests for setup module)
- [x] `pnpm build` — compiles without errors
- [ ] Manual smoke test: run `create-innovator` end-to-end and verify dependencies install and snapshots update

🤖 Generated with [Claude Code](https://claude.com/claude-code)