### PR TITLE
docs: document --latest / -l flag in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Entry point: `src/cli.ts` — uses `citty` for arg parsing and `@clack/prompts` 
 **CLI flow** (sequential):
 
 1. `ensureGitHubAuth()` — reads/prompts for GitHub PAT, validates scopes + org access, saves to `~/.npmrc`
-2. `ensureGhCli()` → `selectVersion()` → `cloneTemplate()` — requires `gh` CLI, fetches tags via Octokit, shallow-clones at selected tag, re-inits git
+2. `ensureGhCli()` → `selectVersion()` / `selectLatestVersion()` → `cloneTemplate()` — requires `gh` CLI, fetches tags via Octokit, lets user pick a version (or auto-selects latest with `--latest`), shallow-clones at selected tag, re-inits git
 3. `replaceTemplateNames()` — replaces `innovator-template` in all text files with the project name (kebab-case, camelCase, PascalCase, Title Case variants)
 4. `setupProject()` — installs deps via pnpm and updates test snapshots; **never throws** (failures show manual instructions instead)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npx create-innovator
 | Flag             | Alias | Description                                                 |
 | ---------------- | ----- | ----------------------------------------------------------- |
 | `--name <name>`  | `-n`  | Project name (skips the interactive prompt)                 |
+| `--latest`       | `-l`  | Skip version selection and use the latest version           |
 | `--experimental` | `-e`  | Include pre-release template versions in the version picker |
 
 ### Examples
@@ -46,6 +47,12 @@ Create a project with a specific name:
 pnpm create innovator --name my-project
 ```
 
+Use the latest template version without prompting:
+
+```bash
+pnpm create innovator --latest
+```
+
 Include experimental template versions:
 
 ```bash
@@ -55,7 +62,7 @@ pnpm create innovator --experimental
 ### What happens when you run it
 
 1. **GitHub authentication** — reads your token from `~/.npmrc` or prompts you to enter one. Validates required scopes (`repo`, `read:packages`) and access to the `stormreply` organization.
-2. **Version selection** — fetches available template tags and lets you pick a version.
+2. **Version selection** — fetches available template tags and lets you pick a version (or auto-selects the latest when `--latest` is used).
 3. **Clone** — shallow-clones the template at the selected tag using `gh repo clone`, then re-initializes a fresh git repository.
 4. **Name replacement** — replaces `innovator-template` throughout the project with your chosen name in all case variants (kebab-case, camelCase, PascalCase, Title Case).
 5. **Template cleanup** — removes template-specific files that are not needed in the new project.


### PR DESCRIPTION
## Summary
- Documents the new `--latest` / `-l` CLI flag in the options table, examples, and workflow description in README.md
- Updates CLAUDE.md architecture section to mention `selectLatestVersion()` alongside `selectVersion()`

## Test plan
- [x] Documentation-only change, no code modified
- [x] All 60 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)